### PR TITLE
Error while accessing args using get helper

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -18,7 +18,7 @@ export function localCopy(pathOrGetter, initializer) {
     let getter =
       typeof pathOrGetter === 'function'
         ? (obj, last) => pathOrGetter(obj, key, last)
-        : argsRegex.test(pathOrGetter)
+        : pathOrGetter.includes('args.')
         ? obj => obj.args[pathOrGetter]
         : obj => get(obj, pathOrGetter);
 


### PR DESCRIPTION
Passing a string path to localCopy uses `Ember.get` and it fails for `this.args`...

[Here's a bug report in Ember repo](https://github.com/emberjs/ember.js/issues/18606)

```ts
@localCopy('args.pageSize', 50) pageSize;
```

```
Assertion Failed: args proxies do not have real property descriptors, so you should never need to call getOwnPropertyDescriptor yourself. This code exists for enumerability, such as in for-in loops and Object.keys()
```