### PR TITLE
add failing test for @dedupedTracked without an initializer

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -148,7 +148,7 @@ export function dedupeTracked(target, key, desc) {
   return {
     get() {
       if (!values.has(this)) {
-        let value = initializer.call(this);
+        let value = initializer?.call(this);
         values.set(this, value);
         set.call(this, value);
       }

--- a/tests/unit/dedupe-tracked-test.js
+++ b/tests/unit/dedupe-tracked-test.js
@@ -31,4 +31,34 @@ module('Unit | Utils | @dedupeTracked', () => {
     assert.equal(person.name, 'Zoey', 'name is correct');
     assert.equal(count, 2, 'getter is called again after updating to a different value');
   });
+
+  test('it works without an initializer', (assert) => {
+    let count = 0;
+
+    class Person {
+      @dedupeTracked _name;
+
+      @cached
+      get name() {
+        count++;
+
+        return this._name;
+      }
+    }
+
+    const person = new Person();
+
+    assert.equal(person.name, undefined, 'name should start as undefined');
+    assert.equal(count, 1, 'getter is called the first time');
+
+    person._name = undefined;
+
+    assert.equal(person.name, undefined, 'name is still undefined');
+    assert.equal(count, 1, 'getter is not called again after updating to the same value');
+
+    person._name = 'Zoey';
+
+    assert.equal(person.name, 'Zoey', 'name is correct');
+    assert.equal(count, 2, 'getter is called again after updating to a different value');
+  });
 });


### PR DESCRIPTION
`@dedupedTracked` decorator seems to be failing if used without initializing the property.