### PR TITLE
Fix missing `since` option for `local-copy-memo-fn` deprecation

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -33,6 +33,7 @@ export function localCopy(memo, initializer) {
   deprecate('Using a memoization function with @localCopy has been deprecated. Consider using @trackedReset instead.', typeof memo !== 'function', {
     id: 'local-copy-memo-fn',
     for: 'tracked-toolbox',
+    since: '1.2.3',
     until: '2.0.0',
   });
 


### PR DESCRIPTION
Closes #36