### PR TITLE
Add ability to pass a custom comparator to `dedupe-tracked`

### DIFF
--- a/tests/unit/dedupe-tracked-test.js
+++ b/tests/unit/dedupe-tracked-test.js
@@ -61,4 +61,57 @@ module('Unit | Utils | @dedupeTracked', () => {
     assert.equal(person.name, 'Zoey', 'name is correct');
     assert.equal(count, 2, 'getter is called again after updating to a different value');
   });
+
+  test('it requires no parameters or exactly one comparator', (assert) => {
+    assert.throws(() => {
+      // eslint-disable-next-line no-unused-vars
+      class Person {
+        @dedupeTracked() _name;
+      }
+    });
+
+    assert.throws(() => {
+      // eslint-disable-next-line no-unused-vars
+      class Person {
+        @dedupeTracked(1) _name;
+      }
+    });
+
+    assert.throws(() => {
+      // eslint-disable-next-line no-unused-vars
+      class Person {
+        @dedupeTracked(() => true, 1) _name;
+      }
+    });
+  });
+
+  test('it works when passed a custom comparator', (assert) => {
+    let count = 0;
+
+    class Person {
+      @dedupeTracked((a, b) => a.length === b.length) _name = 'foo';
+
+      @cached
+      get name() {
+        count++;
+
+        return this._name;
+      }
+    }
+
+    const person = new Person();
+
+    assert.equal(person.name, 'foo', 'name is correct');
+    assert.equal(count, 1, 'getter is called the first time');
+
+    person._name = 'bar';
+
+    assert.equal(person.name, 'foo', 'name is correct');
+    assert.equal(count, 1, 'getter is not called again after updating to the "same" value');
+
+    person._name = 'Zoey';
+
+    assert.equal(person.name, 'Zoey', 'name is correct');
+    assert.equal(count, 2, 'getter is called again after updating to a different value');
+  });
 });


### PR DESCRIPTION
I just hit a case where I needed that so I decided to make it a feature! :smile: In my case I need to shallowly-compare objects. One also might need to deeply-compare objects/arrays/whatever.

The negative point to this PR is that:

1) it's a breaking change as parentheses are needed so make sure to release it in a major version!
2) parentheses are needed even when no custom comparator is needed.

cc @SergeAstapov, @chriskrycho