### PR TITLE
Move `ember-cli-htmlbars` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   },
   "dependencies": {
     "ember-cache-primitive-polyfill": "^1.0.0",
-    "ember-cli-babel": "^7.26.6",
-    "ember-cli-htmlbars": "^5.7.1"
+    "ember-cli-babel": "^7.26.6"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -43,6 +42,7 @@
     "ember-auto-import": "^2.2.3",
     "ember-cli": "~3.28.3",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^5.7.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",


### PR DESCRIPTION
There are no has files provided by the add-on hence there is no need to include `ember-cli-htmlbars` in `dependencies`