### PR TITLE
Drop support for Node 12

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -57,7 +57,7 @@
     }
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || 16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -68,7 +68,7 @@
     "webpack": "^5.72.0"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
@chriskrycho #66 actually didn't update engine field in `package.json` so this PR does