### PR TITLE
Remove deprecated localCopy memo function variant

### DIFF
--- a/addon/src/index.js
+++ b/addon/src/index.js
@@ -2,20 +2,6 @@ import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
-import {
-  macroCondition,
-  dependencySatisfies,
-  importSync,
-} from '@embroider/macros';
-
-let deprecate;
-
-if (macroCondition(dependencySatisfies('ember-source', '^3.28.0 || ^4.0.0'))) {
-  deprecate = importSync('@ember/debug').deprecate;
-} else {
-  // eslint-disable-next-line no-undef
-  deprecate = Ember.deprecate;
-}
 
 class Meta {
   prevRemote;
@@ -41,29 +27,16 @@ function getOrCreateMeta(instance, metas, initializer) {
 
 export function localCopy(memo, initializer) {
   assert(
-    `@localCopy() must be given a memo path or memo function as its first argument, received \`${String(
+    `@localCopy() must be given a memo path as its first argument, received \`${String(
       memo
     )}\``,
-    typeof memo === 'string' || typeof memo === 'function'
-  );
-  deprecate(
-    'Using a memoization function with @localCopy has been deprecated. Consider using @trackedReset instead.',
-    typeof memo !== 'function',
-    {
-      id: 'local-copy-memo-fn',
-      for: 'tracked-toolbox',
-      since: '1.2.3',
-      until: '2.0.0',
-    }
+    typeof memo === 'string'
   );
 
   let metas = new WeakMap();
 
-  return (_prototype, key) => {
-    let memoFn =
-      typeof memo === 'function'
-        ? (obj, last) => memo.call(obj, obj, key, last)
-        : (obj) => get(obj, memo);
+  return (/* prototype, key, desc */) => {
+    let memoFn = (obj) => get(obj, memo);
 
     return {
       get() {

--- a/test-app/tests/unit/local-copy-test.js
+++ b/test-app/tests/unit/local-copy-test.js
@@ -34,36 +34,6 @@ module('Unit | Utils | @localCopy', () => {
     assert.strictEqual(remote.value, 789, 'remote value is updated');
   });
 
-  test('it works with a getter', function (assert) {
-    class Remote {
-      value = 123;
-    }
-
-    let remote = new Remote();
-
-    class Local {
-      @localCopy(() => remote.value) value;
-    }
-
-    let local = new Local();
-
-    assert.strictEqual(local.value, 123, 'defaults to the remote value');
-
-    local.value = 456;
-
-    assert.strictEqual(local.value, 456, 'local value updates correctly');
-    assert.strictEqual(remote.value, 123, 'remote value does not update');
-
-    remote.value = 789;
-
-    assert.strictEqual(
-      local.value,
-      789,
-      'local value updates to new remote value'
-    );
-    assert.strictEqual(remote.value, 789, 'remote value is updated');
-  });
-
   test('it requires a path or getter', function (assert) {
     assert.throws(() => {
       class Local {
@@ -71,7 +41,7 @@ module('Unit | Utils | @localCopy', () => {
       }
 
       new Local();
-    }, /@localCopy\(\) must be given a memo path or memo function/);
+    }, /@localCopy\(\) must be given a memo path/);
   });
 
   test('value initializer works', function (assert) {


### PR DESCRIPTION
This was deprecated in v1.2.3, released April 2021, because it was buggy and mostly did not work. If you were relying on it, use `@trackedReset` instead.