### PR TITLE
Add `repository` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "addon",
     "test-app"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:tracked-tools/tracked-toolbox.git"
+  },
   "scripts": {
     "prepare": "cd addon && yarn build",
     "release": "release-it",


### PR DESCRIPTION
This should unblock publishing. Without it attempting to run `release-it` produces:

```
ERROR Could not infer "repo" from the "package.json" file.
```