### PR TITLE
Deprecate @cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ ember install tracked-toolbox
 
 #### `@cached`
 
+> [!TIP]
+> If you're using Ember v4.1.0 or newer, use `@cached` decorator imported from
+> [`@glimmer/tracking`](https://api.emberjs.com/ember/release/functions/@glimmer%2Ftracking/cached) instead. For more information, see [RFC #566](https://rfcs.emberjs.com/id/0566-memo-decorator)
+
 Adds weak-caching to a getter, so that it tracks its execution, and only updates
 when tracked state that the getter used changes.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,9 +167,6 @@ importers:
       decorator-transforms:
         specifier: ^2.3.0
         version: 2.3.0(@babel/core@7.27.1)
-      ember-cache-primitive-polyfill:
-        specifier: ^1.0.0
-        version: 1.0.1(@babel/core@7.27.1)
     devDependencies:
       '@babel/core':
         specifier: ^7.25.2
@@ -1827,12 +1824,6 @@ packages:
       '@babel/core': ^7.0.0
       webpack: '>=2'
 
-  babel-plugin-debug-macros@0.2.0:
-    resolution: {integrity: sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-beta.42
-
   babel-plugin-debug-macros@0.3.4:
     resolution: {integrity: sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==}
     engines: {node: '>=6'}
@@ -2833,10 +2824,6 @@ packages:
     resolution: {integrity: sha512-bcBFDYVTFHyqyq8BNvsj6UO3pE6Uqou/cNmee0WaqBgZ+1nQqFz0UE26usrtnFAT+YaFZSkqF2H36QW84k0/cg==}
     engines: {node: 12.* || 14.* || >= 16}
 
-  ember-cache-primitive-polyfill@1.0.1:
-    resolution: {integrity: sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==}
-    engines: {node: 10.* || >= 12}
-
   ember-cli-babel-plugin-helpers@1.1.1:
     resolution: {integrity: sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -2929,10 +2916,6 @@ packages:
     resolution: {integrity: sha512-adcz01uGDrqBPniZrrYx6+tHe58ikc6j+cbX4+3aTG2OVJvQSL+LeisI6ixxtEZeklHRFB6FE6U1etTS6nRVfQ==}
     engines: {node: '>= 18'}
     hasBin: true
-
-  ember-compatibility-helpers@1.2.7:
-    resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
-    engines: {node: 10.* || >= 12.*}
 
   ember-eslint-parser@0.5.9:
     resolution: {integrity: sha512-IW4/3cEiFp49M2LiKyzi7VcT1egogOe8UxQ9eUKTooenC7Q4qNhzTD6rOZ8j51m8iJC+8hCzjbNCa3K4CN0Hhg==}
@@ -8695,11 +8678,6 @@ snapshots:
       schema-utils: 2.7.1
       webpack: 5.99.8
 
-  babel-plugin-debug-macros@0.2.0(@babel/core@7.27.1):
-    dependencies:
-      '@babel/core': 7.27.1
-      semver: 5.7.2
-
   babel-plugin-debug-macros@0.3.4(@babel/core@7.27.1):
     dependencies:
       '@babel/core': 7.27.1
@@ -9915,16 +9893,6 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-cache-primitive-polyfill@1.0.1(@babel/core@7.27.1):
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 5.1.2
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.27.1)
-      silent-error: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   ember-cli-babel-plugin-helpers@1.1.1: {}
 
   ember-cli-babel@7.26.11:
@@ -10281,17 +10249,6 @@ snapshots:
       - velocityjs
       - walrus
       - whiskers
-
-  ember-compatibility-helpers@1.2.7(@babel/core@7.27.1):
-    dependencies:
-      babel-plugin-debug-macros: 0.2.0(@babel/core@7.27.1)
-      ember-cli-version-checker: 5.1.2
-      find-up: 5.0.0
-      fs-extra: 9.1.0
-      semver: 5.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   ember-eslint-parser@0.5.9(@babel/core@7.27.1)(eslint@9.26.0):
     dependencies:

--- a/tracked-toolbox/package.json
+++ b/tracked-toolbox/package.json
@@ -37,8 +37,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.10.0",
-    "decorator-transforms": "^2.3.0",
-    "ember-cache-primitive-polyfill": "^1.0.0"
+    "decorator-transforms": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/tracked-toolbox/src/index.js
+++ b/tracked-toolbox/src/index.js
@@ -1,7 +1,6 @@
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { get } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
+import { tracked, cached as glimmerCached } from '@glimmer/tracking';
 
 class Meta {
   prevRemote;
@@ -123,26 +122,21 @@ export function trackedReset(memoOrConfig) {
 }
 
 export function cached(target, key, value) {
-  assert('@cached can only be used on getters', value && value.get);
-
-  let { get, set } = value;
-
-  let caches = new WeakMap();
-
-  return {
-    get() {
-      let cache = caches.get(this);
-
-      if (cache === undefined) {
-        cache = createCache(get.bind(this));
-        caches.set(this, cache);
-      }
-
-      return getValue(cache);
+  deprecate(
+    "Importing @cached decorator from tracked-toolbox is deprecated. Please replace it with `import { cached } from '@glimmer/tracking';`",
+    false,
+    {
+      id: 'tracked-toolbox::cached-decorator',
+      for: 'tracked-toolbox',
+      since: {
+        available: '2.1.0',
+        enabled: '2.1.0',
+      },
+      until: '3.0.0',
     },
+  );
 
-    set,
-  };
+  return glimmerCached(target, key, value);
 }
 
 export function dedupeTracked() {


### PR DESCRIPTION
#209 

This removes the implementation for the `@cached` decorator in favor of a re-export from `@glimmer/tracking`. Tests are left in place to make sure the decorator works as intended.