### PR TITLE
Deprecate @cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ ember install tracked-toolbox
 
 #### `@cached`
 
+> [!TIP]
+> If you're using Ember v4.1.0 or newer, use `@cached` decorator imported from
+> [`@glimmer/tracking`](https://api.emberjs.com/ember/release/functions/@glimmer%2Ftracking/cached) instead. For more information, see [RFC #566](https://rfcs.emberjs.com/id/0566-memo-decorator)
+
 Adds weak-caching to a getter, so that it tracks its execution, and only updates
 when tracked state that the getter used changes.
 

--- a/tracked-toolbox/src/index.js
+++ b/tracked-toolbox/src/index.js
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { get } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
@@ -123,6 +123,20 @@ export function trackedReset(memoOrConfig) {
 }
 
 export function cached(target, key, value) {
+  deprecate(
+    "Importing @cached decorator from tracked-toolbox is deprecated. Please replace it with `import { cached } from '@glimmer/tracking';`",
+    false,
+    {
+      id: 'tracked-toolbox::cached-decorator',
+      for: 'tracked-toolbox',
+      since: {
+        available: '2.1.0',
+        enabled: '2.1.0',
+      },
+      until: '3.0.0',
+    },
+  );
+
   assert('@cached can only be used on getters', value && value.get);
 
   let { get, set } = value;


### PR DESCRIPTION
resolves #209 

This marks the build tin implementation for the `@cached` decorator as deprecated, with plan to remove in next major version.

[Starting with Ember.js 4.1](https://blog.emberjs.com/ember-4-1-released/), this is available out of the box